### PR TITLE
Modifies blobflake props:

### DIFF
--- a/src/components/BlobFlake/BlobFlake.tsx
+++ b/src/components/BlobFlake/BlobFlake.tsx
@@ -52,7 +52,8 @@ const BlobFlake: FunctionComponent<BlobFlakeProps> = (props) => {
   const {
     plainText,
     size,
-    forcedAspects,
+    absoluteAspects,
+    clampedAspects,
     aspectRanges,
     linearColourA,
     linearColourB,
@@ -72,22 +73,25 @@ const BlobFlake: FunctionComponent<BlobFlakeProps> = (props) => {
           !dynamicallyConstrainedAspects.includes(aspect)
       )
       .forEach(([aspect, range]: [string, [number, number]]) => {
-        const propValue = forcedAspects?.[aspect as keyof NormalAspects];
+        const absoluteValue = absoluteAspects?.[aspect as keyof NormalAspects];
+        const clampedValue = clampedAspects?.[aspect as keyof NormalAspects];
 
         generated[aspect as keyof NormalAspects] =
-          propValue ??
+          absoluteValue ??
           range[0] +
-            decimalFromString(`${plainText}-${aspect}`) * (range[1] - range[0]);
+            (clampedValue ?? decimalFromString(`${plainText}-${aspect}`)) *
+              (range[1] - range[0]);
       });
 
     return generated as GeneratableAspects;
-  }, [ranges, forcedAspects, plainText]);
+  }, [ranges, absoluteAspects, clampedAspects, plainText]);
 
   const depth = useDynamicallyConstrainedAspect(
     ranges.depth,
     `${plainText}-depth`,
     size / 8,
-    forcedAspects?.depth
+    absoluteAspects?.depth,
+    clampedAspects?.depth
   );
 
   /**
@@ -98,7 +102,8 @@ const BlobFlake: FunctionComponent<BlobFlakeProps> = (props) => {
     ranges.squishMagnitude,
     `${plainText}`,
     depth,
-    forcedAspects?.squishMagnitude
+    absoluteAspects?.squishMagnitude,
+    clampedAspects?.squishMagnitude
   );
 
   const [squishX, squishY] = useMemo(() => {

--- a/src/components/BlobFlake/BlobFlake.types.ts
+++ b/src/components/BlobFlake/BlobFlake.types.ts
@@ -35,5 +35,6 @@ export interface BlobFlakeProps {
   linearColourA?: string;
   linearColourB?: string;
   aspectRanges?: Partial<GeneratableAspectRanges>;
-  forcedAspects?: Partial<GeneratableAspects>;
+  clampedAspects?: Partial<GeneratableAspects>;
+  absoluteAspects?: Partial<GeneratableAspects>;
 }

--- a/src/hooks/useDynamicallyConstrainedAspect.ts
+++ b/src/hooks/useDynamicallyConstrainedAspect.ts
@@ -5,14 +5,17 @@ const useDynamicallyConstrainedAspect = (
   range: [number, number],
   plainText: string,
   basedOn: number,
-  forcedValue?: number
+  absoluteAspect?: number,
+  clampedAspect?: number
 ) => {
   return useMemo(
     () =>
-      forcedValue ??
-      (range[0] + decimalFromString(plainText) * (range[1] - range[0])) *
+      absoluteAspect ??
+      (range[0] +
+        (clampedAspect ?? decimalFromString(plainText)) *
+          (range[1] - range[0])) *
         basedOn,
-    [basedOn, forcedValue, plainText, range]
+    [absoluteAspect, range, clampedAspect, plainText, basedOn]
   );
 };
 


### PR DESCRIPTION
Adds:
 - `BlobFlake` prop `absoluteAspects`: Specify an exact value for an aspect.
 - `BlobFlake` prop `clampedAspects`: Specify a number between 0 and 1 which is used alongside `aspectRanges` to set a value for an aspect

Removes:
 - `BlobFlake` prop `forcedAspects`: Replaced by `absoluteAspects`, identical functionality